### PR TITLE
Updated vertex positioning and linearize_depth to conform to reverse-z

### DIFF
--- a/scenes/gameplay/combined_edge_detection.gdshader
+++ b/scenes/gameplay/combined_edge_detection.gdshader
@@ -25,7 +25,7 @@ const mat3 sobel_x = mat3(
 
 float linearize_depth(vec2 uv_coord, mat4 proj_matrix){
 	float depth = texture(DEPTH_TEXTURE, uv_coord).x;
-	vec3 ndc = vec3(uv_coord, depth) * 2.0 - 1.0;
+	vec3 ndc = vec3(uv_coord, depth) * 2.0 - 0.0;
 	vec4 view = proj_matrix * vec4(ndc, 1.0);
 	view.xyz /= view.w;
 	float linear_depth = -view.z;
@@ -37,17 +37,17 @@ vec3 normalize_normal(vec3 normal){
 }
 
 void vertex(){
-	POSITION = vec4(VERTEX, 1.0);
+	POSITION = vec4(VERTEX.xy, 1.0, 1.0);
 }
 
 void fragment() {
 	vec2 uv = SCREEN_UV;
 	vec4 screen_color = texture(SCREEN_TEXTURE, uv);
 	vec2 screen_pixel_size = 0.5 / VIEWPORT_SIZE;
-	
+
 	// depth section
 	float depth = linearize_depth(uv, INV_PROJECTION_MATRIX);
-	
+
 	float n = linearize_depth(uv + vec2(0.0, -screen_pixel_size.y), INV_PROJECTION_MATRIX);
 	float s = linearize_depth(uv + vec2(0.0, screen_pixel_size.y), INV_PROJECTION_MATRIX);
 	float e = linearize_depth(uv + vec2(screen_pixel_size.x, 0.0), INV_PROJECTION_MATRIX);
@@ -56,21 +56,21 @@ void fragment() {
 	float ne = linearize_depth(uv + vec2(screen_pixel_size.x, -screen_pixel_size.y), INV_PROJECTION_MATRIX);
 	float sw = linearize_depth(uv + vec2(-screen_pixel_size.x, screen_pixel_size.y), INV_PROJECTION_MATRIX);
 	float se = linearize_depth(uv + vec2(screen_pixel_size.x, screen_pixel_size.y), INV_PROJECTION_MATRIX);
-	
+
 	mat3 depth_surrounding_pixels = mat3(
 		vec3(nw, n, ne),
 		vec3(w, depth, e),
 		vec3(sw, s, se)
 	);
-	
+
 	float depth_edge_x = dot(sobel_x[0], depth_surrounding_pixels[0]) + dot(sobel_x[1], depth_surrounding_pixels[1]) + dot(sobel_x[2], depth_surrounding_pixels[2]);
 	float depth_edge_y = dot(sobel_y[0], depth_surrounding_pixels[0]) + dot(sobel_y[1], depth_surrounding_pixels[1]) + dot(sobel_y[2], depth_surrounding_pixels[2]);
-	
+
 	float depth_edge = sqrt(pow(depth_edge_x, 2.0)+pow(depth_edge_y, 2.0));
-	
+
 	// normal section
 	vec3 normal = normalize_normal(texture(NORMAL_TEXTURE, uv).rgb);
-	
+
 	vec3 n_n = normalize_normal(texture(NORMAL_TEXTURE, uv + vec2(0.0, -screen_pixel_size.y)).rgb);
 	vec3 n_s = normalize_normal(texture(NORMAL_TEXTURE, uv + vec2(0.0, screen_pixel_size.y)).rgb);
 	vec3 n_e = normalize_normal(texture(NORMAL_TEXTURE, uv + vec2(screen_pixel_size.x, 0.0)).rgb);
@@ -79,18 +79,18 @@ void fragment() {
 	vec3 n_ne = normalize_normal(texture(NORMAL_TEXTURE, uv + vec2(screen_pixel_size.x, -screen_pixel_size.y)).rgb);
 	vec3 n_sw = normalize_normal(texture(NORMAL_TEXTURE, uv + vec2(-screen_pixel_size.x, screen_pixel_size.y)).rgb);
 	vec3 n_se = normalize_normal(texture(NORMAL_TEXTURE, uv + vec2(screen_pixel_size.x, screen_pixel_size.y)).rgb);
-	
+
 	mat3 normal_surrounding_pixels = mat3(
 		vec3(length(n_nw-normal), length(n_n-normal), length(n_ne-normal)),
 		vec3(length(n_w-normal), length(normal-normal), length(n_e-normal)),
 		vec3(length(n_sw-normal), length(n_s-normal), length(n_se-normal))
 	);
-	
+
 	float normal_edge_x = dot(sobel_x[0], normal_surrounding_pixels[0]) + dot(sobel_x[1], normal_surrounding_pixels[1]) + dot(sobel_x[2], normal_surrounding_pixels[2]);
 	float normal_edge_y = dot(sobel_y[0], normal_surrounding_pixels[0]) + dot(sobel_y[1], normal_surrounding_pixels[1]) + dot(sobel_y[2], normal_surrounding_pixels[2]);
-	
+
 	float normal_edge = sqrt(pow(normal_edge_x, 2.0)+pow(normal_edge_y, 2.0));
-	
+
 	if (normal_edge > normal_edge_threshold) {
 		ALBEDO = line_color;
 	} else if (depth_edge > depth_edge_threshold_lower && normal_edge > 0.0) {

--- a/scenes/gameplay/depth-based-edge-detection.gdshader
+++ b/scenes/gameplay/depth-based-edge-detection.gdshader
@@ -22,7 +22,7 @@ const mat3 sobel_x = mat3(
 
 float linearize_depth(vec2 uv_coord, mat4 proj_matrix){
 	float depth = texture(DEPTH_TEXTURE, uv_coord).x;
-	vec3 ndc = vec3(uv_coord, depth) * 2.0 - 1.0;
+	vec3 ndc = vec3(uv_coord, depth) * 2.0 - 0.0;
 	vec4 view = proj_matrix * vec4(ndc, 1.0);
 	view.xyz /= view.w;
 	float linear_depth = -view.z;
@@ -30,17 +30,17 @@ float linearize_depth(vec2 uv_coord, mat4 proj_matrix){
 }
 
 void vertex(){
-	POSITION = vec4(VERTEX, 1.0);
+	POSITION = vec4(VERTEX.xy, 1.0, 1.0);
 }
 
 void fragment() {
 	vec2 uv = SCREEN_UV;
 	vec4 screen_color = texture(SCREEN_TEXTURE, uv);
-	
+
 	float depth = linearize_depth(uv, INV_PROJECTION_MATRIX);
-	
+
 	vec2 offset = 0.5 / VIEWPORT_SIZE;
-	
+
 	float n = linearize_depth(uv + vec2(0.0, -offset.y), INV_PROJECTION_MATRIX);
 	float s = linearize_depth(uv + vec2(0.0, offset.y), INV_PROJECTION_MATRIX);
 	float e = linearize_depth(uv + vec2(offset.x, 0.0), INV_PROJECTION_MATRIX);
@@ -49,18 +49,18 @@ void fragment() {
 	float ne = linearize_depth(uv + vec2(offset.x, -offset.y), INV_PROJECTION_MATRIX);
 	float sw = linearize_depth(uv + vec2(-offset.x, offset.y), INV_PROJECTION_MATRIX);
 	float se = linearize_depth(uv + vec2(offset.x, offset.y), INV_PROJECTION_MATRIX);
-	
+
 	mat3 surrounding_pixels = mat3(
 		vec3(nw, n, ne),
 		vec3(w, depth, e),
 		vec3(sw, s, se)
 	);
-	
+
 	float edge_x = dot(sobel_x[0], surrounding_pixels[0]) + dot(sobel_x[1], surrounding_pixels[1]) + dot(sobel_x[2], surrounding_pixels[2]);
 	float edge_y = dot(sobel_y[0], surrounding_pixels[0]) + dot(sobel_y[1], surrounding_pixels[1]) + dot(sobel_y[2], surrounding_pixels[2]);
-	
+
 	float edge = sqrt(pow(edge_x, 2.0)+pow(edge_y, 2.0));
-	
+
 	if (edge > edge_threshold) {
 		ALBEDO = line_color;
 	} else {

--- a/scenes/gameplay/noise-overlay-spatial.gdshader
+++ b/scenes/gameplay/noise-overlay-spatial.gdshader
@@ -7,7 +7,7 @@ uniform float strength: hint_range(0.0, 5, 0.1) = 1.0;
 uniform float uv_scaling: hint_range (0.0, 1.0, 0.05) = 1.0;
 
 void vertex(){
-	POSITION = vec4(VERTEX, 1.0);
+	POSITION = vec4(VERTEX.xy, 1.0, 1.0);
 }
 
 void fragment() {

--- a/scenes/gameplay/normal-based-edge-detection.gdshader.gdshader
+++ b/scenes/gameplay/normal-based-edge-detection.gdshader.gdshader
@@ -25,7 +25,7 @@ vec3 normalize_normal(vec3 normal){
 }
 
 void vertex(){
-	POSITION = vec4(VERTEX, 1.0);
+	POSITION = vec4(VERTEX.xy, 1.0, 1.0);
 }
 
 void fragment() {

--- a/scenes/gameplay/shadow_hatching.gdshader
+++ b/scenes/gameplay/shadow_hatching.gdshader
@@ -13,7 +13,7 @@ uniform sampler2D HATCH_TEXTURE_G: repeat_enable, filter_linear;
 uniform sampler2D HATCH_TEXTURE_B: repeat_enable, filter_linear;
 
 void vertex(){
-	POSITION = vec4(VERTEX, 1.0);
+	POSITION = vec4(VERTEX.xy, 1.0, 1.0);
 }
 
 void fragment() {
@@ -22,13 +22,13 @@ void fragment() {
 	vec3 hatch_texture_r = 1.0 - texture(HATCH_TEXTURE_R, uv * uv_scaling).rgb;
 	vec3 hatch_texture_g = 1.0 - texture(HATCH_TEXTURE_G, uv * uv_scaling).rgb;
 	vec3 hatch_texture_b = 1.0 - texture(HATCH_TEXTURE_B, uv * uv_scaling).rgb;
-	
+
 	float luminance = 0.299*screen_color.r + 0.587*screen_color.g + 0.144*screen_color.b;
-	
+
 	float contrast = u_contrast;
 	luminance = (luminance - 0.5 + u_offset) * contrast + 0.5;
 	luminance = clamp(luminance, 0.0, 1.0);
-	
+
 	screen_color.rgb = background_color;
 	if (luminance < 0.75) {
 		screen_color = screen_color - hatch_texture_r;
@@ -39,6 +39,6 @@ void fragment() {
 	if (luminance < 0.25) {
 		screen_color = screen_color - hatch_texture_b;
 	}
-	
+
 	ALBEDO = screen_color.rgb;
 }


### PR DESCRIPTION
Godot 4.3 introduced breaking changes to z-depth for shaders, outlined here: https://godotengine.org/article/introducing-reverse-z/. I made the necessary changes and it seems to be working on 4.3 now! I found this demo project and your shaders helpful so here's the PR if you want!